### PR TITLE
Simple type validation in QueryFragment derive.

### DIFF
--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -9,9 +9,11 @@ use crate::{
 
 mod cynic_arguments;
 mod schema_parsing;
+mod type_validation;
 
 use cynic_arguments::{arguments_from_field_attrs, FieldArgument};
 use schema_parsing::{Field, Object, Schema};
+use type_validation::check_types_are_compatible;
 
 pub fn fragment_derive(ast: &syn::DeriveInput) -> Result<TokenStream, syn::Error> {
     fragment_derive_impl(ast, parse_struct_attrs(&ast.attrs)?)
@@ -329,6 +331,8 @@ impl FragmentImpl {
                     let field_name = Ident::for_field(&field_name);
 
                     if let Some(gql_field) = object.fields.get(&field_name) {
+                        check_types_are_compatible(&gql_field.field_type, &field.ty)?;
+
                         let argument_structs = argument_structs(
                             arguments,
                             gql_field,

--- a/cynic-codegen/src/fragment_derive/type_validation.rs
+++ b/cynic-codegen/src/fragment_derive/type_validation.rs
@@ -1,0 +1,185 @@
+use crate::FieldType;
+
+pub fn check_types_are_compatible(
+    gql_type: &FieldType,
+    rust_type: &syn::Type,
+) -> Result<(), syn::Error> {
+    use quote::quote;
+    use syn::spanned::Spanned;
+
+    let parsed_type = parse_type(rust_type);
+
+    if parsed_type == ParsedType::Unknown {
+        return Err(syn::Error::new(
+            rust_type.span(),
+            "Cynic does not understand this type. Only un-parameterised types, Vecs & Options are accepted currently.",
+        ));
+    }
+
+    if gql_type.is_nullable() {
+        if let ParsedType::Optional(inner) = parsed_type {
+            return check_types_are_compatible(&gql_type.as_required(), &inner);
+        } else {
+            return Err(syn::Error::new(
+                        rust_type.span(),
+                        format!(
+                            "This GraphQL type is optional but you're not wrapping the type in Option.  Did you mean Option<{}>", 
+                            quote! { #rust_type }
+                        )
+                    ));
+        }
+    } else if let ParsedType::Optional(inner) = parsed_type {
+        return Err(syn::Error::new(
+                        rust_type.span(),
+                        format!(
+                            "This GraphQL type is required but you're wrapping the type in Option.  Did you mean {}", 
+                            quote! { #inner }
+                        )
+                    ));
+    } else if let FieldType::List(item_type, _) = gql_type {
+        if let ParsedType::List(inner) = parsed_type {
+            return check_types_are_compatible(&item_type, &inner);
+        } else {
+            return Err(syn::Error::new(
+                        rust_type.span(),
+                        format!(
+                            "This GraphQL type is a list but you're not wrapping the type in Vec.  Did you mean Vec<{}>", 
+                            quote! { #rust_type }
+                        )
+                    ));
+        }
+    } else if let ParsedType::List(inner) = parsed_type {
+        return Err(syn::Error::new(
+                        rust_type.span(),
+                        format!(
+                            "This GraphQL type is not a list but you're wrapping the type in Vec.  Did you mean {}", 
+                            quote! { #inner }
+                        )
+                    ));
+    }
+
+    Ok(())
+}
+
+/// A simplified rust type structure
+#[derive(Debug, PartialEq)]
+enum ParsedType<'a> {
+    Optional(&'a syn::Type),
+    List(&'a syn::Type),
+    SimpleType,
+    Unknown,
+}
+
+fn parse_type<'a>(ty: &'a syn::Type) -> ParsedType<'a> {
+    if let syn::Type::Path(type_path) = ty {
+        if let Some(last_segment) = type_path.path.segments.last() {
+            if last_segment.ident.to_string() == "Option" {
+                if let syn::PathArguments::AngleBracketed(angle_bracketed) = &last_segment.arguments
+                {
+                    for arg in &angle_bracketed.args {
+                        if let syn::GenericArgument::Type(inner_type) = arg {
+                            return ParsedType::Optional(inner_type);
+                        }
+                    }
+                }
+                return ParsedType::Unknown;
+            } else if last_segment.ident.to_string() == "Vec" {
+                if let syn::PathArguments::AngleBracketed(angle_bracketed) = &last_segment.arguments
+                {
+                    for arg in &angle_bracketed.args {
+                        if let syn::GenericArgument::Type(inner_type) = arg {
+                            return ParsedType::List(inner_type);
+                        }
+                    }
+                }
+                return ParsedType::Unknown;
+            }
+
+            if last_segment.arguments == syn::PathArguments::None {
+                return ParsedType::SimpleType;
+            }
+        }
+    }
+
+    ParsedType::Unknown
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{FieldType, TypePath};
+    use assert_matches::assert_matches;
+    use quote::quote;
+
+    #[test]
+    fn test_required_validation() {
+        let required_field = FieldType::Scalar(TypePath::empty(), false);
+        let optional_field = FieldType::Scalar(TypePath::empty(), true);
+
+        assert_matches!(
+            check_types_are_compatible(&required_field, &syn::parse2(quote! { i32 }).unwrap()),
+            Ok(())
+        );
+        assert_matches!(
+            check_types_are_compatible(
+                &optional_field,
+                &syn::parse2(quote! { Option<i32> }).unwrap()
+            ),
+            Ok(())
+        );
+        assert_matches!(
+            check_types_are_compatible(&optional_field, &syn::parse2(quote! { i32 }).unwrap()),
+            Err(_)
+        );
+        assert_matches!(
+            check_types_are_compatible(
+                &required_field,
+                &syn::parse2(quote! { Option<i32> }).unwrap()
+            ),
+            Err(_)
+        );
+    }
+
+    #[test]
+    fn test_list_validation() {
+        let list = FieldType::List(Box::new(FieldType::Scalar(TypePath::empty(), false)), false);
+        let optional_list =
+            FieldType::List(Box::new(FieldType::Scalar(TypePath::empty(), false)), true);
+        let option_list_option =
+            FieldType::List(Box::new(FieldType::Scalar(TypePath::empty(), true)), true);
+
+        assert_matches!(
+            check_types_are_compatible(&list, &syn::parse2(quote! { Vec<i32> }).unwrap()),
+            Ok(())
+        );
+        assert_matches!(
+            check_types_are_compatible(
+                &optional_list,
+                &syn::parse2(quote! { Option<Vec<i32>> }).unwrap()
+            ),
+            Ok(())
+        );
+        assert_matches!(
+            check_types_are_compatible(
+                &option_list_option,
+                &syn::parse2(quote! { Option<Vec<Option<i32>>> }).unwrap()
+            ),
+            Ok(())
+        );
+        assert_matches!(
+            check_types_are_compatible(&list, &syn::parse2(quote! { i32 }).unwrap()),
+            Err(_)
+        );
+        assert_matches!(
+            check_types_are_compatible(&optional_list, &syn::parse2(quote! { Vec<i32> }).unwrap()),
+            Err(_)
+        );
+        assert_matches!(
+            check_types_are_compatible(
+                &option_list_option,
+                &syn::parse2(quote! { Option<Vec<i32>> }).unwrap()
+            ),
+            Err(_)
+        );
+    }
+}


### PR DESCRIPTION
When writing QueryFragments, it's really easy to get confused about
what GraphQL types are required, what are lists etc.  When you get this
wrong, the Rust compile errors are either not as helpful as they could
be _or_ plain confusing.

This updates the QueryFragment derive code to be a bit smarter here: it
will specifically check for the cases where there's a mismatch in list
types or optionalness.

I've also updated it to error when people provide generic types in their
structs.  Currently this will cause a syntax error in the derive output,
with an unhelpful message, so I'm just explicitly disallowing it for
now.  Can revisit fixing the underlying error at some point.