### PR TITLE
Add support for union types via InlineFragments trait.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,8 @@ name = "cynic"
 version = "0.1.2"
 dependencies = [
  "cynic-codegen 0.1.2",
- "json-decode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "json-decode 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -420,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "json-decode"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -453,6 +454,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "matches"
@@ -1214,11 +1220,12 @@ dependencies = [
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
-"checksum json-decode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b61ae8b61186791a5afb22038f1e70384eb719ecfa3afd804742ece4b9f44e3"
+"checksum json-decode 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be5b9232f973af7b36ff305570bb1f9efba061d32c89847e6a1684f6b1748a5b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -296,6 +296,7 @@ struct FragmentImpl {
     selector_struct_path: TypePath,
     constructor_params: Vec<ConstructorParameter>,
     argument_struct: syn::Type,
+    graphql_type_name: String,
 }
 
 impl FragmentImpl {
@@ -382,6 +383,7 @@ impl FragmentImpl {
             selector_struct_path,
             constructor_params,
             argument_struct,
+            graphql_type_name: graphql_type_name.to_string(),
         })
     }
 }
@@ -395,6 +397,7 @@ impl quote::ToTokens for FragmentImpl {
         let selector_struct = &self.selector_struct_path;
         let fields = &self.fields;
         let constructor_params = &self.constructor_params;
+        let graphql_type = proc_macro2::Literal::string(&self.graphql_type_name);
         let constructor_param_names = self
             .constructor_params
             .iter()
@@ -421,6 +424,10 @@ impl quote::ToTokens for FragmentImpl {
                             #fields
                         ),*
                     )
+                }
+
+                fn graphql_type() -> String {
+                    #graphql_type.to_string()
                 }
             }
         })

--- a/cynic-codegen/src/inline_fragments_derive/attributes.rs
+++ b/cynic-codegen/src/inline_fragments_derive/attributes.rs
@@ -1,0 +1,69 @@
+use crate::attributes::{extract_meta_attrs, Attribute};
+
+#[derive(Debug)]
+pub struct InlineFragmentsDeriveAttributes {
+    pub schema_path: Attribute,
+    pub query_module: Attribute,
+    pub graphql_type: Attribute,
+    pub argument_struct: Option<Attribute>,
+}
+
+pub fn parse(attrs: &Vec<syn::Attribute>) -> Result<InlineFragmentsDeriveAttributes, syn::Error> {
+    let (mut attr_map, attr_span) = extract_meta_attrs::<DeriveAttribute>(attrs)?;
+
+    let schema_path = attr_map
+        .remove(&DeriveAttribute::SchemaPath)
+        .ok_or(syn::Error::new(
+            attr_span,
+            "Missing required attribute: schema_path",
+        ))?;
+
+    let query_module = attr_map
+        .remove(&DeriveAttribute::QueryModule)
+        .ok_or(syn::Error::new(
+            attr_span,
+            "Missing required attribute: query_module",
+        ))?;
+
+    let graphql_type = attr_map
+        .remove(&DeriveAttribute::GraphqlType)
+        .ok_or(syn::Error::new(
+            attr_span,
+            "Missing required attribute: graphql_type",
+        ))?;
+
+    let argument_struct = attr_map.remove(&DeriveAttribute::ArgumentStruct);
+
+    Ok(InlineFragmentsDeriveAttributes {
+        schema_path,
+        query_module,
+        graphql_type,
+        argument_struct,
+    })
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+enum DeriveAttribute {
+    SchemaPath,
+    QueryModule,
+    GraphqlType,
+    ArgumentStruct,
+}
+
+impl std::str::FromStr for DeriveAttribute {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<DeriveAttribute, String> {
+        if s == "schema_path" {
+            Ok(DeriveAttribute::SchemaPath)
+        } else if s == "query_module" {
+            Ok(DeriveAttribute::QueryModule)
+        } else if s == "graphql_type" {
+            Ok(DeriveAttribute::GraphqlType)
+        } else if s == "argument_struct" {
+            Ok(DeriveAttribute::ArgumentStruct)
+        } else {
+            Err(format!("Unknown cynic attribute: {}.  Expected one of schema_path, query_module, graphql_type or argument_struct", s))
+        }
+    }
+}

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -1,0 +1,169 @@
+use proc_macro2::{Span, TokenStream};
+
+use crate::{Ident, TypePath};
+
+mod attributes;
+use attributes::InlineFragmentsDeriveAttributes;
+
+pub fn inline_fragments_derive(ast: &syn::DeriveInput) -> Result<TokenStream, syn::Error> {
+    inline_fragments_derive_impl(ast, attributes::parse(&ast.attrs)?)
+}
+
+fn inline_fragments_derive_impl(
+    ast: &syn::DeriveInput,
+    attributes: InlineFragmentsDeriveAttributes,
+) -> Result<TokenStream, syn::Error> {
+    use quote::{quote, quote_spanned};
+
+    let schema = std::fs::read_to_string(&attributes.schema_path.value).map_err(|e| {
+        syn::Error::new(
+            attributes.schema_path.span,
+            format!("Could not load schema file: {}", e),
+        )
+    })?;
+
+    let schema = graphql_parser::schema::parse_schema(&schema).map_err(|e| {
+        syn::Error::new(
+            attributes.schema_path.span,
+            format!("Could not parse schema file: {}", e),
+        )
+    })?;
+
+    if !find_union_type(&attributes.graphql_type.value, &schema) {
+        return Err(syn::Error::new(
+            attributes.graphql_type.span,
+            format!(
+                "Could not find a Union type named {}",
+                attributes.graphql_type.value
+            ),
+        ));
+    }
+
+    let argument_struct = if let Some(arg_struct) = attributes.argument_struct {
+        let arg_struct_val = Ident::new(&arg_struct.value);
+        let argument_struct = quote_spanned! { arg_struct.span => #arg_struct_val };
+        syn::parse2(argument_struct)?
+    } else {
+        syn::parse2(quote! { () })?
+    };
+
+    if let syn::Data::Enum(data_enum) = &ast.data {
+        let inline_fragments_impl = InlineFragmentsImpl {
+            target_struct: ast.ident.clone(),
+            type_lock: TypePath::concat(&[
+                Ident::new_spanned(&attributes.query_module.value, attributes.query_module.span)
+                    .into(),
+                Ident::for_type(&attributes.graphql_type.value).into(),
+            ]),
+            argument_struct,
+            possible_types: possible_types_from_enum(data_enum)?,
+            graphql_type_name: attributes.graphql_type.value,
+        };
+
+        Ok(quote! { #inline_fragments_impl })
+    } else {
+        Err(syn::Error::new(
+            Span::call_site(),
+            format!("InlineFragments can only be derived from an enum"),
+        ))
+    }
+}
+
+fn possible_types_from_enum(
+    data_enum: &syn::DataEnum,
+) -> Result<Vec<(syn::Ident, syn::Type)>, syn::Error> {
+    use syn::{spanned::Spanned, Fields};
+
+    let mut result = vec![];
+    for variant in &data_enum.variants {
+        match &variant.fields {
+            Fields::Unnamed(fields) => {
+                if fields.unnamed.len() != 1 {
+                    return Err(syn::Error::new(
+                        variant.fields.span(),
+                        "InlineFragments derive requires enum variants to have one field",
+                    ));
+                }
+                let field = fields.unnamed.first().unwrap();
+                result.push((variant.ident.clone(), field.ty.clone()));
+            }
+            Fields::Named(_) => {
+                return Err(syn::Error::new(
+                    variant.fields.span(),
+                    "Can't derive InlineFragments on an enum with named fields",
+                ))
+            }
+            Fields::Unit => {
+                return Err(syn::Error::new(
+                    variant.fields.span(),
+                    "Can't derive InlineFragments on an enum with a unit variant",
+                ))
+            }
+        }
+    }
+    Ok(result)
+}
+
+struct InlineFragmentsImpl {
+    target_struct: syn::Ident,
+    type_lock: TypePath,
+    argument_struct: syn::Type,
+    possible_types: Vec<(syn::Ident, syn::Type)>,
+    graphql_type_name: String,
+}
+
+impl quote::ToTokens for InlineFragmentsImpl {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        use quote::{quote, TokenStreamExt};
+
+        let target_struct = &self.target_struct;
+        let type_lock = &self.type_lock;
+        let arguments = &self.argument_struct;
+        let internal_types: Vec<_> = self.possible_types.iter().map(|(_, ty)| ty).collect();
+        let variants: Vec<_> = self.possible_types.iter().map(|(v, _)| v).collect();
+        let graphql_type = proc_macro2::Literal::string(&self.graphql_type_name);
+
+        tokens.append_all(quote! {
+            impl ::cynic::InlineFragments for #target_struct {
+                type TypeLock = #type_lock;
+                type Arguments = #arguments;
+
+                fn fragments(arguments: Self::Arguments) ->
+                Vec<(String, ::cynic::SelectionSet<'static, Self, Self::TypeLock>)>
+                {
+                    use ::cynic::QueryFragment;
+
+                    let mut rv = vec![];
+                    #(
+                        rv.push((
+                            #internal_types::graphql_type(),
+                            #internal_types::fragment(arguments)
+                                .map(#target_struct::#variants)
+                                .transform_typelock()
+                        ));
+                    )*
+                    rv
+                }
+
+                fn graphql_type() -> String {
+                    #graphql_type.to_string()
+                }
+            }
+        });
+    }
+}
+
+fn find_union_type(name: &str, schema: &graphql_parser::schema::Document) -> bool {
+    for definition in &schema.definitions {
+        use graphql_parser::schema::{Definition, TypeDefinition};
+        match definition {
+            Definition::TypeDefinition(TypeDefinition::Union(union)) => {
+                if union.name == name {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+    }
+    return false;
+}

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -9,6 +9,7 @@ mod fragment_arguments_derive;
 mod fragment_derive;
 mod graphql_extensions;
 mod ident;
+mod inline_fragments_derive;
 mod module;
 mod query_dsl;
 mod struct_field;
@@ -48,6 +49,18 @@ pub fn fragment_arguments_derive(input: TokenStream) -> TokenStream {
     let ast = syn::parse_macro_input!(input as syn::DeriveInput);
 
     let rv = match fragment_arguments_derive::fragment_arguments_derive(&ast) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_error().into(),
+    };
+
+    rv
+}
+
+#[proc_macro_derive(InlineFragments, attributes(cynic))]
+pub fn inline_fragments_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    let rv = match inline_fragments_derive::inline_fragments_derive(&ast) {
         Ok(tokens) => tokens.into(),
         Err(e) => e.to_compile_error().into(),
     };

--- a/cynic-codegen/src/query_dsl/interface_struct.rs
+++ b/cynic-codegen/src/query_dsl/interface_struct.rs
@@ -1,0 +1,32 @@
+use proc_macro2::TokenStream;
+
+use crate::Ident;
+
+/// We generate an InterfaceStruct for each interface in the schema.
+///
+/// These are output as empty structs that can be used as the TypeLock
+/// in a SelectorStruct.
+#[derive(Debug)]
+pub struct InterfaceStruct {
+    pub name: Ident,
+}
+
+impl InterfaceStruct {
+    pub fn from_interface(interface: &graphql_parser::schema::InterfaceType) -> Self {
+        InterfaceStruct {
+            name: Ident::for_type(&interface.name),
+        }
+    }
+}
+
+impl quote::ToTokens for InterfaceStruct {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        use quote::{quote, TokenStreamExt};
+
+        let name = &self.name;
+
+        tokens.append_all(quote! {
+            pub struct #name {}
+        });
+    }
+}

--- a/cynic-codegen/src/query_dsl/mod.rs
+++ b/cynic-codegen/src/query_dsl/mod.rs
@@ -4,6 +4,7 @@ mod argument_struct;
 mod field_selector;
 mod graphql_enum;
 mod input_struct;
+mod interface_struct;
 mod selector_struct;
 mod union_struct;
 
@@ -14,6 +15,7 @@ pub use argument_struct::ArgumentStruct;
 pub use field_selector::FieldSelector;
 use graphql_enum::GraphQLEnum;
 use input_struct::InputStruct;
+use interface_struct::InterfaceStruct;
 pub use selector_struct::SelectorStruct;
 use union_struct::UnionStruct;
 
@@ -54,6 +56,7 @@ pub struct QueryDsl {
     pub argument_struct_modules: Vec<Module<ArgumentStruct>>,
     pub inputs: Vec<InputStruct>,
     pub unions: Vec<UnionStruct>,
+    pub interfaces: Vec<InterfaceStruct>,
 }
 
 impl From<graphql_parser::schema::Document> for QueryDsl {
@@ -67,6 +70,7 @@ impl From<graphql_parser::schema::Document> for QueryDsl {
         let mut argument_struct_modules = vec![];
         let mut inputs = vec![];
         let mut unions = vec![];
+        let mut interfaces = vec![];
 
         let root_query_type = find_root_query(&document.definitions);
 
@@ -115,6 +119,9 @@ impl From<graphql_parser::schema::Document> for QueryDsl {
                 Definition::TypeDefinition(TypeDefinition::Union(union)) => {
                     unions.push(UnionStruct::from_union(&union));
                 }
+                Definition::TypeDefinition(TypeDefinition::Interface(interface)) => {
+                    interfaces.push(InterfaceStruct::from_interface(&interface));
+                }
                 _ => {}
             }
         }
@@ -125,6 +132,7 @@ impl From<graphql_parser::schema::Document> for QueryDsl {
             argument_struct_modules,
             inputs,
             unions,
+            interfaces,
         }
     }
 }
@@ -155,6 +163,7 @@ impl quote::ToTokens for QueryDsl {
         let argument_struct_modules = &self.argument_struct_modules;
         let inputs = &self.inputs;
         let unions = &self.unions;
+        let interfaces = &self.interfaces;
 
         tokens.append_all(quote! {
             #(
@@ -162,6 +171,9 @@ impl quote::ToTokens for QueryDsl {
             )*
             #(
                 #unions
+            )*
+            #(
+                #interfaces
             )*
             #(
                 #selectors

--- a/cynic-codegen/src/query_dsl/union_struct.rs
+++ b/cynic-codegen/src/query_dsl/union_struct.rs
@@ -1,0 +1,39 @@
+use proc_macro2::TokenStream;
+
+use crate::Ident;
+
+/// We generate a UnionStruct for each union in the schema.
+///
+/// These are output as empty structs that can be used as the TypeLock
+/// in a SelectorStruct.
+#[derive(Debug)]
+pub struct UnionStruct {
+    pub name: Ident,
+    pub subtypes: Vec<Ident>,
+}
+
+impl UnionStruct {
+    pub fn from_union(union: &graphql_parser::schema::UnionType) -> Self {
+        UnionStruct {
+            name: Ident::for_type(&union.name),
+            subtypes: union.types.iter().map(|ty| Ident::for_type(ty)).collect(),
+        }
+    }
+}
+
+impl quote::ToTokens for UnionStruct {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        use quote::{quote, TokenStreamExt};
+
+        let name = &self.name;
+        let subtypes = &self.subtypes;
+
+        tokens.append_all(quote! {
+            pub struct #name {}
+
+            #(
+                impl ::cynic::selection_set::HasSubtype<#subtypes> for #name {}
+            )*
+        });
+    }
+}

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -12,10 +12,13 @@ documentation = "https://docs.rs/cynic"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-json-decode = "0.1.0"
+json-decode = "0.2.0"
 serde = { version = "1.0.104", features = [ "derive" ] }
 serde_json = "1.0.44"
 cynic-codegen = { path = "../cynic-codegen", version = "0.1.2" }
+
+[dev-dependencies]
+maplit = "1.0.2"
 
 
 [[example]]

--- a/cynic/examples/simple.graphql
+++ b/cynic/examples/simple.graphql
@@ -2,6 +2,7 @@ scalar JSON
 
 type Query {
   testStruct: TestStruct
+  myUnion: MyUnionType
 }
 
 type TestStruct {
@@ -10,6 +11,8 @@ type TestStruct {
   optNested: Nested
   json: JSON
 }
+
+union MyUnionType = Nested | TestStruct
 
 type Nested {
   aString: String!

--- a/cynic/examples/simple.rs
+++ b/cynic/examples/simple.rs
@@ -55,6 +55,17 @@ impl Test {
     }
 }
 
+#[derive(cynic::InlineFragments)]
+#[cynic(
+    schema_path = "cynic/examples/simple.graphql",
+    query_module = "query_dsl",
+    graphql_type = "MyUnionType"
+)]
+enum MyUnionType {
+    Test(Test),
+    Nested(Nested),
+}
+
 /*
 fn query() {
     let query = query_dsl::Query::test_struct(selection_set::map2(

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -16,7 +16,6 @@
 //!
 //! ```rust
 //! mod query_dsl {
-//! #   type Node = String;
 //!     cynic::query_dsl!("../examples/examples/starwars.schema.graphql");
 //! }
 //! ```
@@ -46,7 +45,6 @@
 //!
 //! ```rust
 //! # mod query_dsl {
-//! #    type Node = String;
 //! #   cynic::query_dsl!("../examples/examples/starwars.schema.graphql");
 //! # }
 //!
@@ -110,7 +108,6 @@
 //!
 //! ```rust
 //! # mod query_dsl {
-//! #    type Node = String;
 //! #   cynic::query_dsl!("../examples/examples/starwars.schema.graphql");
 //! # }
 //!

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -1,8 +1,4 @@
 mod query_dsl {
-    // This is 100% wrong - a node is an interface w/
-    // an id field.  Gets it to compile for now though...
-    type Node = String;
-
     cynic::query_dsl!("examples/examples/starwars.schema.graphql");
 }
 


### PR DESCRIPTION
This adds an InlineFragments trait that can be used to describe a
GraphQL inline fragment.  This trait can currently be derived on an enum
in order to provide support for querying union types.  I've plans to
expand this to support interfaces in the future, but this isn't done
just yet.

This also provides a stub struct to any interface definitions, that can be
used as a TypeLock on fields that provide these interfaces.  We still
don't support actually querying interfaces, this just means we can
output a query_dsl for a schema with interfaces without error.

Full support for interfaces will come in a future PR.