### PR TITLE
Add scalars_as_strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ all APIs might be changed.
 - Fixed a few things that stop the examples in the documentation from
   compiling.
 - Fixed all the tests
+- We now use the correct case for non built-in scalar types
 
 ## v0.1.2 - 2020-02-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ all APIs might be changed.
 - Split the procedural macros out into their own cynic-proc-macros crate.
   cynic-codegen now exists as a re-usable library for programatically 
   doing the codegen.
+- The IntoArguments trait is now named FromArguments and has had it's
+  parameters switched up.
 
 ### Bug Fixes
 
@@ -35,6 +37,8 @@ all APIs might be changed.
   compiling.
 - Fixed all the tests
 - We now use the correct case for non built-in scalar types
+- Fixed an issue that prevented propagation of argument structs into inner
+  QueryFragments
 
 ## v0.1.2 - 2020-02-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ all APIs might be changed.
 - Added `scalars_as_strings` for stubbing out all scalar types as strings.
   A temporary measure until I can come up with an easier way to manage large
   numbers of scalars.
+- Added an `output_query_dsl` function suitable for running inside build.rs
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ all APIs might be changed.
 - Added a StarWars API example
 - `#[derive(QueryFragment)]` now explicitly checks for required/list type
   mismatches & other easy mistakes, and warns the user appropriately.
+- Added `scalars_as_strings` for stubbing out all scalar types as strings.
+  A temporary measure until I can come up with an easier way to manage large
+  numbers of scalars.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ all APIs might be changed.
   A temporary measure until I can come up with an easier way to manage large
   numbers of scalars.
 
+### Changed
+
+- Split the procedural macros out into their own cynic-proc-macros crate.
+  cynic-codegen now exists as a re-usable library for programatically 
+  doing the codegen.
+
 ### Bug Fixes
 
 - Now supports schemas that define their root query types.  Before we just

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cynic"
 version = "0.1.2"
 dependencies = [
- "cynic-codegen 0.1.2",
+ "cynic-proc-macros 0.1.2",
  "json-decode 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -155,6 +155,14 @@ version = "0.1.0"
 dependencies = [
  "cynic 0.1.2",
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cynic-proc-macros"
+version = "0.1.2"
+dependencies = [
+ "cynic-codegen 0.1.2",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
 members = [
-    "cynic", "cynic-codegen", "examples"
+    "cynic", "cynic-codegen", "cynic-proc-macros", "examples"
 ]

--- a/cynic-codegen/Cargo.toml
+++ b/cynic-codegen/Cargo.toml
@@ -10,6 +10,10 @@ documentation = "https://docs.rs/cynic-codegen"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["rustfmt"]
+rustfmt = []
+
 [dependencies]
 graphql-parser = "0.2.3"
 proc-macro2 = "1.0.7"

--- a/cynic-codegen/Cargo.toml
+++ b/cynic-codegen/Cargo.toml
@@ -10,9 +10,6 @@ documentation = "https://docs.rs/cynic-codegen"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[lib]
-proc-macro = true
-
 [dependencies]
 graphql-parser = "0.2.3"
 proc-macro2 = "1.0.7"

--- a/cynic-codegen/src/field_type.rs
+++ b/cynic-codegen/src/field_type.rs
@@ -41,7 +41,7 @@ impl FieldType {
             Type::NamedType(name) => {
                 if type_index.is_scalar(name) {
                     FieldType::Scalar(
-                        TypePath::concat(&[type_path, Ident::for_inbuilt_scalar(name).into()]),
+                        TypePath::concat(&[type_path, Ident::for_type(name).into()]),
                         nullable,
                     )
                 } else if type_index.is_enum(name) {

--- a/cynic-codegen/src/fragment_arguments_derive/mod.rs
+++ b/cynic-codegen/src/fragment_arguments_derive/mod.rs
@@ -7,8 +7,8 @@ pub fn fragment_arguments_derive(ast: &syn::DeriveInput) -> Result<TokenStream, 
     Ok(quote! {
         impl ::cynic::FragmentArguments for #ident {}
 
-        impl ::cynic::IntoArguments<()> for #ident {
-            fn into_args(&self) -> () {
+        impl ::cynic::FromArguments<#ident> for () {
+            fn from_arguments(_: &#ident) -> () {
                 ()
             }
         }

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -231,7 +231,7 @@ impl quote::ToTokens for FieldSelectorCall {
         let inner_call = if self.contains_composite {
             let field_type = &self.query_fragment_field_type;
             quote! {
-                #initial_args #field_type::fragment(args.into_args())
+                #initial_args #field_type::fragment(FromArguments::from_arguments(&args))
             }
         } else {
             quote! {#initial_args}
@@ -412,7 +412,7 @@ impl quote::ToTokens for FragmentImpl {
                 type Arguments = #argument_struct;
 
                 fn fragment(args: Self::Arguments) -> Self::SelectionSet {
-                    use ::cynic::{QueryFragment, IntoArguments};
+                    use ::cynic::{QueryFragment, FromArguments};
 
                     let new = |#(#constructor_params),*| #target_struct {
                         #(#constructor_param_names),*

--- a/cynic-codegen/src/ident.rs
+++ b/cynic-codegen/src/ident.rs
@@ -6,24 +6,24 @@ use proc_macro2::{Span, TokenStream};
 pub struct Ident(String, Option<Span>);
 
 impl Ident {
-    pub fn new(s: &str) -> Self {
-        Ident(s.to_string(), None)
+    pub fn new<T: Into<String>>(s: T) -> Self {
+        Ident(s.into(), None)
     }
 
-    pub fn new_spanned(s: &str, span: Span) -> Ident {
-        Ident(s.to_string(), Some(span))
+    pub fn new_spanned<T: Into<String>>(s: T, span: Span) -> Ident {
+        Ident(s.into(), Some(span))
     }
 
-    pub fn for_inbuilt_scalar(s: &str) -> Self {
-        Ident(transform_keywords(s.to_string()), None)
+    pub fn for_inbuilt_scalar<T: Into<String>>(s: T) -> Self {
+        Ident(transform_keywords(s.into()), None)
     }
 
-    pub fn for_type(s: &str) -> Self {
-        Ident(transform_keywords(s.to_pascal_case()), None)
+    pub fn for_type<T: AsRef<str>>(s: T) -> Self {
+        Ident(transform_keywords(s.as_ref().to_pascal_case()), None)
     }
 
-    pub fn for_field(s: &str) -> Self {
-        Ident(transform_keywords(s.to_snake_case()), None)
+    pub fn for_field<T: AsRef<str>>(s: T) -> Self {
+        Ident(transform_keywords(s.as_ref().to_snake_case()), None)
     }
 
     pub fn for_module(s: &str) -> Self {

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -22,7 +22,35 @@ use type_index::TypeIndex;
 use type_path::TypePath;
 
 
+pub fn output_query_dsl<P: AsRef<std::path::Path>>(schema: P, output_path: P) -> Result<(), Error> {
+    use query_dsl::QueryDslParams;
+    use std::io::Write;
 
+    let tokens = query_dsl::query_dsl_from_schema(QueryDslParams {
+        schema_filename: schema.as_ref().to_str().unwrap().to_string(),
+    })?;
 
+    {
+        let mut out = std::fs::File::create(output_path.as_ref()).unwrap();
+        write!(&mut out, "{}", tokens).unwrap();
+    }
 
+    format_code(output_path.as_ref());
+
+    Ok(())
+}
+
+#[allow(unused_variables)]
+fn format_code(filename: &std::path::Path) {
+    #[cfg(feature = "rustfmt")]
+    {
+        std::process::Command::new("cargo")
+            .args(&["fmt", "--", filename.to_str().unwrap()])
+            .spawn()
+            .expect("failed to execute process");
+    }
+    #[cfg(not(feature = "rustfmt"))]
+    {
+        return code;
+    }
 }

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -1,18 +1,15 @@
-extern crate proc_macro;
-
-use proc_macro::TokenStream;
+pub mod fragment_arguments_derive;
+pub mod fragment_derive;
+pub mod inline_fragments_derive;
+pub mod query_dsl;
+pub mod scalars_as_strings;
 
 mod attributes;
 mod error;
 mod field_type;
-mod fragment_arguments_derive;
-mod fragment_derive;
 mod graphql_extensions;
 mod ident;
-mod inline_fragments_derive;
 mod module;
-mod query_dsl;
-mod scalars_as_strings;
 mod struct_field;
 mod type_index;
 mod type_path;
@@ -24,62 +21,8 @@ use struct_field::StructField;
 use type_index::TypeIndex;
 use type_path::TypePath;
 
-#[proc_macro]
-pub fn query_dsl(input: TokenStream) -> TokenStream {
-    let input = syn::parse_macro_input!(input as query_dsl::QueryDslParams);
 
-    let rv = query_dsl::query_dsl_from_schema(input).unwrap().into();
 
-    //eprintln!("{}", rv);
 
-    rv
-}
 
-#[proc_macro]
-pub fn scalars_as_strings(input: TokenStream) -> TokenStream {
-    let input = syn::parse_macro_input!(input as scalars_as_strings::Params);
-
-    let rv = scalars_as_strings::scalars_as_strings(input)
-        .unwrap()
-        .into();
-
-    //eprintln!("{}", rv);
-
-    rv
-}
-
-#[proc_macro_derive(QueryFragment, attributes(cynic, cynic_arguments))]
-pub fn query_fragment_derive(input: TokenStream) -> TokenStream {
-    let ast = syn::parse_macro_input!(input as syn::DeriveInput);
-
-    let rv = match fragment_derive::fragment_derive(&ast) {
-        Ok(tokens) => tokens.into(),
-        Err(e) => e.to_compile_error().into(),
-    };
-
-    rv
-}
-
-#[proc_macro_derive(FragmentArguments)]
-pub fn fragment_arguments_derive(input: TokenStream) -> TokenStream {
-    let ast = syn::parse_macro_input!(input as syn::DeriveInput);
-
-    let rv = match fragment_arguments_derive::fragment_arguments_derive(&ast) {
-        Ok(tokens) => tokens.into(),
-        Err(e) => e.to_compile_error().into(),
-    };
-
-    rv
-}
-
-#[proc_macro_derive(InlineFragments, attributes(cynic))]
-pub fn inline_fragments_derive(input: TokenStream) -> TokenStream {
-    let ast = syn::parse_macro_input!(input as syn::DeriveInput);
-
-    let rv = match inline_fragments_derive::inline_fragments_derive(&ast) {
-        Ok(tokens) => tokens.into(),
-        Err(e) => e.to_compile_error().into(),
-    };
-
-    rv
 }

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -21,7 +21,6 @@ use struct_field::StructField;
 use type_index::TypeIndex;
 use type_path::TypePath;
 
-
 pub fn output_query_dsl<P: AsRef<std::path::Path>>(schema: P, output_path: P) -> Result<(), Error> {
     use query_dsl::QueryDslParams;
     use std::io::Write;

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -12,6 +12,7 @@ mod ident;
 mod inline_fragments_derive;
 mod module;
 mod query_dsl;
+mod scalars_as_strings;
 mod struct_field;
 mod type_index;
 mod type_path;
@@ -28,6 +29,21 @@ pub fn query_dsl(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as query_dsl::QueryDslParams);
 
     let rv = query_dsl::query_dsl_from_schema(input).unwrap().into();
+
+    //eprintln!("{}", rv);
+
+    rv
+}
+
+#[proc_macro]
+pub fn scalars_as_strings(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as scalars_as_strings::Params);
+
+    let rv = scalars_as_strings::scalars_as_strings(input)
+        .unwrap()
+        .into();
+
+    //eprintln!("{}", rv);
 
     rv
 }

--- a/cynic-codegen/src/query_dsl/field_selector.rs
+++ b/cynic-codegen/src/query_dsl/field_selector.rs
@@ -82,6 +82,7 @@ impl quote::ToTokens for FieldSelector {
             tokens.append_all(quote! {
                 pub fn #rust_field_name(#(#arguments, )*) ->
                 ::cynic::selection_set::SelectionSet<'static, #field_type, #type_lock> {
+                    #![allow(dead_code)]
                     use ::cynic::selection_set::{string, integer, float, boolean};
 
                     let mut args: Vec<::cynic::Argument> = vec![];

--- a/cynic-codegen/src/query_dsl/graphql_enum.rs
+++ b/cynic-codegen/src/query_dsl/graphql_enum.rs
@@ -34,6 +34,7 @@ impl quote::ToTokens for GraphQLEnum {
             .graphql_names
             .iter()
             .map(|n| proc_macro2::Literal::string(&n));
+        let string_enum_name = proc_macro2::Literal::string(&enum_name.to_string());
 
         tokens.append_all(quote! {
             #[derive(PartialEq, Eq, Debug, ::serde::Serialize, ::serde::Deserialize)]
@@ -53,6 +54,10 @@ impl quote::ToTokens for GraphQLEnum {
 
                 fn fragment(args: Self::Arguments) -> Self::SelectionSet {
                     ::cynic::selection_set::serde()
+                }
+
+                fn graphql_type() -> String {
+                    #string_enum_name.to_string()
                 }
             }
         })

--- a/cynic-codegen/src/query_dsl/mod.rs
+++ b/cynic-codegen/src/query_dsl/mod.rs
@@ -21,7 +21,7 @@ use union_struct::UnionStruct;
 
 #[derive(Debug)]
 pub struct QueryDslParams {
-    schema_filename: String,
+    pub schema_filename: String,
 }
 
 impl QueryDslParams {

--- a/cynic-codegen/src/scalars_as_strings.rs
+++ b/cynic-codegen/src/scalars_as_strings.rs
@@ -1,0 +1,71 @@
+use proc_macro2::TokenStream;
+
+use crate::{Error, Ident};
+
+#[derive(Debug)]
+pub struct Params {
+    schema_filename: String,
+}
+
+impl Params {
+    fn new(schema_filename: String) -> Self {
+        Params { schema_filename }
+    }
+}
+
+impl syn::parse::Parse for Params {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        input
+            .parse::<syn::LitStr>()
+            .map(|lit_str| Params::new(lit_str.value()))
+    }
+}
+
+pub fn scalars_as_strings(input: Params) -> Result<TokenStream, Error> {
+    use quote::quote;
+
+    let schema = std::fs::read_to_string(&input.schema_filename)?;
+    let scalars = scalars_from_schema(graphql_parser::schema::parse_schema(&schema)?);
+
+    Ok(quote! {
+        #(scalars),
+    })
+}
+
+fn scalars_from_schema(schema: graphql_parser::schema::Document) -> Vec<StringScalar> {
+    use graphql_parser::schema::{Definition, TypeDefinition};
+
+    let mut rv = vec![];
+    for definition in schema.definitions {
+        match definition {
+            Definition::TypeDefinition(TypeDefinition::Scalar(scalar)) => rv.push(scalar.into()),
+            _ => {}
+        }
+    }
+
+    rv
+}
+
+struct StringScalar {
+    name: Ident,
+}
+
+impl From<graphql_parser::schema::ScalarType> for StringScalar {
+    fn from(scalar: graphql_parser::schema::ScalarType) -> Self {
+        StringScalar {
+            name: Ident::for_type(scalar.name),
+        }
+    }
+}
+
+impl quote::ToTokens for StringScalar {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        use quote::{quote, TokenStreamExt};
+
+        let name = &self.name;
+
+        tokens.append_all(quote! {
+             type #name = String;
+        })
+    }
+}

--- a/cynic-codegen/src/scalars_as_strings.rs
+++ b/cynic-codegen/src/scalars_as_strings.rs
@@ -28,7 +28,7 @@ pub fn scalars_as_strings(input: Params) -> Result<TokenStream, Error> {
     let scalars = scalars_from_schema(graphql_parser::schema::parse_schema(&schema)?);
 
     Ok(quote! {
-        #(scalars),
+        #(#scalars)*
     })
 }
 

--- a/cynic-proc-macros/Cargo.toml
+++ b/cynic-proc-macros/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "cynic-proc-macros"
+version = "0.1.2"
+authors = ["Graeme Coupar <graeme@polyandglot.dev>"]
+edition = "2018"
+homepage = "https://github.com/polyandglot/cynic"
+description = "Procedural macro crate for cynic - a GraphQL query builder & data mapper for Rust"
+license = "MPL-2.0"
+documentation = "https://docs.rs/cynic-proc-macros"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+cynic-codegen = { path = "../cynic-codegen", version = "0.1.2" }
+syn = "1.0.13"

--- a/cynic-proc-macros/src/lib.rs
+++ b/cynic-proc-macros/src/lib.rs
@@ -1,0 +1,72 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+use cynic_codegen::{
+    fragment_arguments_derive, fragment_derive, inline_fragments_derive, query_dsl,
+    scalars_as_strings,
+};
+
+#[proc_macro]
+pub fn query_dsl(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as query_dsl::QueryDslParams);
+
+    let rv = query_dsl::query_dsl_from_schema(input).unwrap().into();
+
+    //eprintln!("{}", rv);
+
+    rv
+}
+
+#[proc_macro]
+pub fn scalars_as_strings(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as scalars_as_strings::Params);
+
+    let rv = scalars_as_strings::scalars_as_strings(input)
+        .unwrap()
+        .into();
+
+    //eprintln!("{}", rv);
+
+    rv
+}
+
+#[proc_macro_derive(QueryFragment, attributes(cynic, cynic_arguments))]
+pub fn query_fragment_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    let rv = match fragment_derive::fragment_derive(&ast) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_error().into(),
+    };
+
+    //eprintln!("{}", rv);
+
+    rv
+}
+
+#[proc_macro_derive(FragmentArguments)]
+pub fn fragment_arguments_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    let rv = match fragment_arguments_derive::fragment_arguments_derive(&ast) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_error().into(),
+    };
+
+    rv
+}
+
+#[proc_macro_derive(InlineFragments, attributes(cynic))]
+pub fn inline_fragments_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    let rv = match inline_fragments_derive::inline_fragments_derive(&ast) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_error().into(),
+    };
+
+    //eprintln!("{}", rv);
+
+    rv
+}

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/cynic"
 json-decode = "0.2.0"
 serde = { version = "1.0.104", features = [ "derive" ] }
 serde_json = "1.0.44"
-cynic-codegen = { path = "../cynic-codegen", version = "0.1.2" }
+cynic-proc-macros = { path = "../cynic-proc-macros", version = "0.1.2" }
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/cynic/examples/simple.rs
+++ b/cynic/examples/simple.rs
@@ -3,14 +3,14 @@ fn main() {
 }
 
 mod query_dsl {
-    type JSON = serde_json::Value;
+    type Json = serde_json::Value;
 
     cynic::query_dsl!("cynic/examples/simple.graphql");
 }
 
 use cynic::selection_set;
 
-#[derive(cynic::FragmentArguments)]
+#[derive(Clone, cynic::FragmentArguments)]
 struct TestArgs {}
 
 #[derive(cynic::QueryFragment)]

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -123,7 +123,7 @@
 //! # }
 //! // Deriving `FragmentArguments` allows this struct to be used as arguments to a
 //! // `QueryFragment` fragment, whether it represents part of a query or a whole query.
-//! #[derive(cynic::FragmentArguments)]
+//! #[derive(cynic::FragmentArguments, Clone)]
 //! struct FilmArguments {
 //!     id: Option<String>
 //! }
@@ -209,7 +209,7 @@ where
 ///
 /// We use this in combination with the IntoArguments trait below
 /// to convert between different argument types in a query heirarchy.
-pub trait FragmentArguments {}
+pub trait FragmentArguments: Clone {}
 
 impl FragmentArguments for () {}
 
@@ -220,25 +220,17 @@ impl FragmentArguments for () {}
 /// but an inner QueryFragment needs none then we can use () as the arguments
 /// type on the inner fragments and use the blanket implementation of IntoArguments
 /// to convert to ().
-///
-/// Similarly, the
-pub trait IntoArguments<T> {
-    fn into_args(&self) -> T;
+pub trait FromArguments<T> {
+    fn from_arguments(args: &T) -> Self;
 }
 
-impl IntoArguments<()> for dyn FragmentArguments {
-    fn into_args(&self) -> () {
-        ()
-    }
-}
-
-impl<T> IntoArguments<T> for T
+impl<T> FromArguments<T> for T
 where
-    T: Clone,
+    T: Clone + FragmentArguments,
 {
-    fn into_args(&self) -> T {
+    fn from_arguments(other: &T) -> Self {
         // TODO: Figure out if there's a way to avoid this clone...
-        self.clone()
+        other.clone()
     }
 }
 

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -250,4 +250,6 @@ pub struct QueryBody<'a> {
     variables: HashMap<String, &'a serde_json::Value>,
 }
 
-pub use cynic_codegen::{query_dsl, FragmentArguments, InlineFragments, QueryFragment};
+pub use cynic_proc_macros::{
+    query_dsl, scalars_as_strings, FragmentArguments, InlineFragments, QueryFragment,
+};

--- a/cynic/tests/simple_schema_tests.rs
+++ b/cynic/tests/simple_schema_tests.rs
@@ -1,12 +1,12 @@
 mod query_dsl {
-    type JSON = serde_json::Value;
+    type Json = serde_json::Value;
 
     cynic::query_dsl!("cynic/examples/simple.graphql");
 }
 
 use cynic::selection_set;
 
-#[derive(cynic::FragmentArguments)]
+#[derive(Clone, cynic::FragmentArguments)]
 struct TestArgs {}
 
 #[derive(cynic::QueryFragment, PartialEq, Debug)]

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -13,7 +13,7 @@ struct Film {
     director: Option<String>,
 }
 
-#[derive(cynic::FragmentArguments)]
+#[derive(Clone, cynic::FragmentArguments)]
 struct FilmArguments {
     id: Option<String>,
 }


### PR DESCRIPTION
This is a workaround to try and help with #5 - users can use this when
getting started to just define all scalars as Strings.  Not the ideal
solution, but it's a starting point.