### PR TITLE
Added `flatten` option at the field level.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ all APIs might be changed.
   A temporary measure until I can come up with an easier way to manage large
   numbers of scalars.
 - Added an `output_query_dsl` function suitable for running inside build.rs
+- Added a flatten option at the field level.  When present this will flatten
+  nested options & vectors into the provided type.  Used to handle the common 
+  case in GQL where someone has defined an optional list of optionals.  This is
+  a pain in Rust, since the same thing can usually be represented by a
+  non-optional list of non-optionals.
 
 ### Changed
 

--- a/cynic-codegen/src/field_type.rs
+++ b/cynic-codegen/src/field_type.rs
@@ -132,6 +132,10 @@ impl FieldType {
                     }
                 }
             }
+
+            // Note: as we no longer require Opt<Vec<Opt<>> to match our types precisely
+            // we go ahead and recurse anyway here...
+            return self.as_required().get_inner_type_from_syn(ty);
         } else if let FieldType::List(inner_self, _) = self {
             if let Type::Path(expr) = ty {
                 if let Some(segment) = expr.path.segments.first() {
@@ -144,6 +148,10 @@ impl FieldType {
                     }
                 }
             }
+
+            // Note: as we no longer require rust types to match GQL types precisely
+            // we go ahead and recurse anyway here...
+            return inner_self.get_inner_type_from_syn(ty);
         }
         ty.clone()
     }

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -160,7 +160,9 @@ mod field;
 mod query;
 mod result;
 mod scalar;
+
 pub mod selection_set;
+pub mod utils;
 
 pub use argument::Argument;
 pub use query::Query;

--- a/cynic/src/utils.rs
+++ b/cynic/src/utils.rs
@@ -1,0 +1,80 @@
+pub trait FlattenFrom<T> {
+    fn flatten_from(args: T) -> Self;
+}
+
+impl<T> FlattenFrom<Option<Vec<Option<T>>>> for Option<Vec<T>> {
+    fn flatten_from(args: Option<Vec<Option<T>>>) -> Option<Vec<T>> {
+        args.map(|v| v.into_iter().flatten().collect())
+    }
+}
+
+impl<T> FlattenFrom<Option<Vec<Option<T>>>> for Vec<T> {
+    fn flatten_from(args: Option<Vec<Option<T>>>) -> Vec<T> {
+        args.map(|v| v.into_iter().flatten().collect())
+            .unwrap_or_else(|| vec![])
+    }
+}
+
+impl<T> FlattenFrom<Option<Vec<T>>> for Vec<T> {
+    fn flatten_from(args: Option<Vec<T>>) -> Vec<T> {
+        args.unwrap_or_else(|| vec![])
+    }
+}
+
+impl<T> FlattenFrom<Vec<Option<T>>> for Vec<T> {
+    fn flatten_from(args: Vec<Option<T>>) -> Vec<T> {
+        args.into_iter().flatten().collect()
+    }
+}
+
+pub trait FlattenInto<T> {
+    fn flatten_into(self) -> T;
+}
+
+impl<T, U> FlattenInto<U> for T
+where
+    U: FlattenFrom<T>,
+{
+    fn flatten_into(self) -> U {
+        U::flatten_from(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_flatten_from_opt_vec_opt() {
+        let ovo = Some(vec![None, Some(1)]);
+        let expected: Vec<i32> = vec![1];
+        let output: Vec<i32> = ovo.flatten_into();
+        assert_eq!(output, expected);
+
+        let ovo = Some(vec![None, Some(1)]);
+        let expected: Option<Vec<i32>> = Some(vec![1]);
+        let output: Option<Vec<i32>> = ovo.flatten_into();
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_flatten_from_opt_vec() {
+        let opt_vec = Some(vec![1]);
+        let expected: Vec<i32> = vec![1];
+        let output: Vec<i32> = opt_vec.flatten_into();
+        assert_eq!(output, expected);
+
+        let opt_vec: Option<Vec<i32>> = None;
+        let expected: Vec<i32> = vec![];
+        let output: Vec<i32> = opt_vec.flatten_into();
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_flatten_from_vec_opt() {
+        let opt_vec = vec![Some(1), None];
+        let expected: Vec<i32> = vec![1];
+        let output: Vec<i32> = opt_vec.flatten_into();
+        assert_eq!(output, expected);
+    }
+}


### PR DESCRIPTION
Used for flattening Option<Vec<Option<T>>> etc. into more usable types.