### PR TITLE
Added query_module attribute macro.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ all APIs might be changed.
 - Added a cynic-querygen for generating QueryFragment structs from a graphql
   schema & query.  This currently has a WIP web interface and a WIP CLI, though
   neither of them are particularly user friendly at this point.
+- Added a `cynic::query_module` attribute macro that can be applied to modules
+  containing QueryFragments & InlineFragments. When this attribute is present
+  the derive will be done for all QueryFragments & InlineFragments contained
+  within.  This allows users to omit some of the parameters these derives
+  usually require, as the query_module attribute provides them and fills them
+  in.  These modules may be expanded in the future to provide more
+  "intelligent" features.
 
 ### Changed
 

--- a/cynic-codegen/src/fragment_derive/input.rs
+++ b/cynic-codegen/src/fragment_derive/input.rs
@@ -1,0 +1,62 @@
+use darling::util::SpannedValue;
+
+#[derive(darling::FromDeriveInput)]
+#[darling(attributes(cynic), supports(struct_named))]
+pub struct FragmentDeriveInput {
+    pub(super) ident: proc_macro2::Ident,
+    pub(super) data: darling::ast::Data<(), FragmentDeriveField>,
+
+    pub schema_path: SpannedValue<String>,
+    pub query_module: SpannedValue<String>,
+    pub graphql_type: SpannedValue<String>,
+    #[darling(default)]
+    pub argument_struct: Option<syn::Ident>,
+}
+
+#[derive(darling::FromField)]
+#[darling(attributes(cynic), forward_attrs(cynic_arguments))]
+pub struct FragmentDeriveField {
+    pub(super) ident: Option<proc_macro2::Ident>,
+    pub(super) ty: syn::Type,
+
+    pub(super) attrs: Vec<syn::Attribute>,
+
+    #[darling(default)]
+    pub(super) flatten: bool,
+}
+
+/// An alternative FragmentDeriveInput struct that doesn't require as many fields.
+///
+/// This is used by the query_module generation, which provides some of the parameters
+/// without the users input.
+#[derive(darling::FromDeriveInput)]
+#[darling(attributes(cynic), supports(struct_named))]
+pub(crate) struct QueryModuleFragmentDeriveInput {
+    ident: proc_macro2::Ident,
+    data: darling::ast::Data<(), crate::fragment_derive::FragmentDeriveField>,
+
+    #[darling(default)]
+    pub schema_path: Option<SpannedValue<String>>,
+    #[darling(default)]
+    pub query_module: Option<SpannedValue<String>>,
+    pub graphql_type: SpannedValue<String>,
+    #[darling(default)]
+    pub argument_struct: Option<syn::Ident>,
+}
+
+impl QueryModuleFragmentDeriveInput {
+    pub fn to_fragment_derive_input(
+        self,
+        schema_path: &SpannedValue<String>,
+        query_module: &SpannedValue<String>,
+    ) -> FragmentDeriveInput {
+        FragmentDeriveInput {
+            ident: self.ident,
+            data: self.data,
+            schema_path: self.schema_path.unwrap_or_else(|| schema_path.clone()),
+            query_module: self.query_module.unwrap_or_else(|| query_module.clone()),
+            graphql_type: self.graphql_type,
+            argument_struct: self.argument_struct,
+        }
+    }
+}

--- a/cynic-codegen/src/fragment_derive/input.rs
+++ b/cynic-codegen/src/fragment_derive/input.rs
@@ -1,3 +1,4 @@
+use crate::load_schema;
 use darling::util::SpannedValue;
 
 #[derive(darling::FromDeriveInput)]

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -9,9 +9,13 @@ mod cynic_arguments;
 mod schema_parsing;
 mod type_validation;
 
+pub(crate) mod input;
+
 use cynic_arguments::{arguments_from_field_attrs, FieldArgument};
 use schema_parsing::{Field, Object, Schema};
 use type_validation::check_types_are_compatible;
+
+pub use input::{FragmentDeriveField, FragmentDeriveInput};
 
 pub fn fragment_derive(ast: &syn::DeriveInput) -> Result<TokenStream, syn::Error> {
     use darling::FromDeriveInput;
@@ -68,31 +72,6 @@ pub fn fragment_derive_impl(input: FragmentDeriveInput) -> Result<TokenStream, s
             format!("QueryFragment can only be derived from a struct"),
         ))
     }
-}
-
-#[derive(darling::FromDeriveInput)]
-#[darling(attributes(cynic), supports(struct_named))]
-pub struct FragmentDeriveInput {
-    ident: proc_macro2::Ident,
-    data: darling::ast::Data<(), FragmentDeriveField>,
-
-    pub schema_path: SpannedValue<String>,
-    pub query_module: SpannedValue<String>,
-    pub graphql_type: SpannedValue<String>,
-    #[darling(default)]
-    pub argument_struct: Option<syn::Ident>,
-}
-
-#[derive(darling::FromField)]
-#[darling(attributes(cynic), forward_attrs(cynic_arguments))]
-struct FragmentDeriveField {
-    ident: Option<proc_macro2::Ident>,
-    ty: syn::Type,
-
-    attrs: Vec<syn::Attribute>,
-
-    #[darling(default)]
-    flatten: bool,
 }
 
 enum SelectorFunction {

--- a/cynic-codegen/src/inline_fragments_derive/input.rs
+++ b/cynic-codegen/src/inline_fragments_derive/input.rs
@@ -1,0 +1,63 @@
+use darling::util::SpannedValue;
+
+#[derive(darling::FromDeriveInput)]
+#[darling(attributes(cynic), supports(enum_newtype))]
+pub struct InlineFragmentsDeriveInput {
+    pub(super) ident: proc_macro2::Ident,
+    pub(super) data: darling::ast::Data<SpannedValue<InlineFragmentsDeriveVariant>, ()>,
+
+    pub schema_path: SpannedValue<String>,
+    pub query_module: SpannedValue<String>,
+    pub graphql_type: SpannedValue<String>,
+    #[darling(default)]
+    pub argument_struct: Option<syn::Ident>,
+}
+
+#[derive(darling::FromVariant)]
+#[darling(attributes(cynic))]
+pub(super) struct InlineFragmentsDeriveVariant {
+    pub ident: proc_macro2::Ident,
+    pub fields: darling::ast::Fields<InlineFragmentsDeriveField>,
+}
+
+#[derive(darling::FromField)]
+#[darling(attributes(cynic))]
+pub(super) struct InlineFragmentsDeriveField {
+    pub ty: syn::Type,
+}
+
+/// An alternative FragmentDeriveInput struct that doesn't require as many fields.
+///
+/// This is used by the query_module generation, which provides some of the parameters
+/// without the users input.
+#[derive(darling::FromDeriveInput)]
+#[darling(attributes(cynic), supports(enum_newtype))]
+pub(crate) struct QueryModuleInlineFragmentsDeriveInput {
+    ident: proc_macro2::Ident,
+    data: darling::ast::Data<SpannedValue<InlineFragmentsDeriveVariant>, ()>,
+
+    #[darling(default)]
+    pub schema_path: Option<SpannedValue<String>>,
+    #[darling(default)]
+    pub query_module: Option<SpannedValue<String>>,
+    pub graphql_type: SpannedValue<String>,
+    #[darling(default)]
+    pub argument_struct: Option<syn::Ident>,
+}
+
+impl QueryModuleInlineFragmentsDeriveInput {
+    pub fn to_inline_fragments_derive_input(
+        self,
+        schema_path: &SpannedValue<String>,
+        query_module: &SpannedValue<String>,
+    ) -> InlineFragmentsDeriveInput {
+        InlineFragmentsDeriveInput {
+            ident: self.ident,
+            data: self.data,
+            schema_path: self.schema_path.unwrap_or_else(|| schema_path.clone()),
+            query_module: self.query_module.unwrap_or_else(|| query_module.clone()),
+            graphql_type: self.graphql_type,
+            argument_struct: self.argument_struct,
+        }
+    }
+}

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -3,6 +3,12 @@ use proc_macro2::{Span, TokenStream};
 
 use crate::{load_schema, Ident, TypePath};
 
+pub mod input;
+
+pub use input::InlineFragmentsDeriveInput;
+
+use input::{InlineFragmentsDeriveField, InlineFragmentsDeriveVariant};
+
 pub fn inline_fragments_derive(ast: &syn::DeriveInput) -> Result<TokenStream, syn::Error> {
     use darling::FromDeriveInput;
 
@@ -12,33 +18,7 @@ pub fn inline_fragments_derive(ast: &syn::DeriveInput) -> Result<TokenStream, sy
     }
 }
 
-#[derive(darling::FromDeriveInput)]
-#[darling(attributes(cynic), supports(enum_newtype))]
-pub struct InlineFragmentsDeriveInput {
-    ident: proc_macro2::Ident,
-    data: darling::ast::Data<SpannedValue<InlineFragmentsDeriveVariant>, ()>,
-
-    pub schema_path: SpannedValue<String>,
-    pub query_module: SpannedValue<String>,
-    pub graphql_type: SpannedValue<String>,
-    #[darling(default)]
-    pub argument_struct: Option<syn::Ident>,
-}
-
-#[derive(darling::FromVariant)]
-#[darling(attributes(cynic))]
-struct InlineFragmentsDeriveVariant {
-    ident: proc_macro2::Ident,
-    fields: darling::ast::Fields<InlineFragmentsDeriveField>,
-}
-
-#[derive(darling::FromField)]
-#[darling(attributes(cynic))]
-struct InlineFragmentsDeriveField {
-    ty: syn::Type,
-}
-
-fn inline_fragments_derive_impl(
+pub(crate) fn inline_fragments_derive_impl(
     input: InlineFragmentsDeriveInput,
 ) -> Result<TokenStream, syn::Error> {
     use quote::{quote, quote_spanned};

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -2,6 +2,7 @@ pub mod fragment_arguments_derive;
 pub mod fragment_derive;
 pub mod inline_fragments_derive;
 pub mod query_dsl;
+pub mod query_module;
 pub mod scalars_as_strings;
 
 mod error;

--- a/cynic-codegen/src/query_module/mod.rs
+++ b/cynic-codegen/src/query_module/mod.rs
@@ -1,0 +1,98 @@
+// TODO: docstring.
+use darling::{util::SpannedValue, FromMeta};
+use proc_macro2::{Span, TokenStream};
+
+mod utils;
+
+use utils::Derive;
+
+#[derive(Debug, FromMeta)]
+struct TransformModuleArgs {
+    schema_path: SpannedValue<String>,
+    // TODO: consider getting rid of query_module at some point (or at least making optional)
+    query_module: SpannedValue<String>,
+}
+
+pub fn transform_query_module(
+    args: syn::AttributeArgs,
+    query_module: syn::ItemMod,
+) -> Result<TokenStream, syn::Error> {
+    match TransformModuleArgs::from_list(&args) {
+        Ok(args) => transform_query_module_impl(args, query_module),
+        Err(e) => Ok(e.write_errors()),
+    }
+}
+
+fn transform_query_module_impl(
+    args: TransformModuleArgs,
+    query_module: syn::ItemMod,
+) -> Result<TokenStream, syn::Error> {
+    use quote::quote;
+
+    let schema = crate::load_schema(&*args.schema_path)
+        .map_err(|e| e.to_syn_error(args.schema_path.span()))?;
+
+    if let None = query_module.content {
+        return Ok(quote! { #query_module });
+    }
+    let (_, module_items) = query_module.content.as_ref().unwrap();
+
+    let derives: Vec<TokenStream> = module_items
+        .into_iter()
+        .map(|i| derive_for_item(i, &args))
+        .collect();
+
+    let (brace, module_items) = query_module.content.unwrap();
+    let module_items: Vec<_> = module_items
+        .into_iter()
+        .map(utils::strip_cynic_attrs)
+        .collect();
+
+    let attrs = query_module.attrs;
+    let visibility = query_module.vis;
+    let module_name = query_module.ident;
+
+    Ok(quote! {
+        #(#attrs)*
+        #visibility mod #module_name {
+            #(#module_items)*
+            #(#derives)*
+        }
+    })
+}
+
+fn derive_for_item(item: &syn::Item, args: &TransformModuleArgs) -> TokenStream {
+    match utils::find_derives(item).first() {
+        None => TokenStream::new(),
+        Some(Derive::QueryFragment) => fragment_derive(item, args),
+    }
+}
+
+fn fragment_derive(item: &syn::Item, args: &TransformModuleArgs) -> TokenStream {
+    use crate::fragment_derive::{fragment_derive_impl, input::QueryModuleFragmentDeriveInput};
+    use darling::FromDeriveInput;
+    use syn::spanned::Spanned;
+
+    let derive_input: syn::DeriveInput = match item {
+        syn::Item::Struct(s) => s.clone().into(),
+        _ => {
+            return syn::Error::new(
+                item.span(),
+                format!("Can only derive QueryFragment on a struct"),
+            )
+            .to_compile_error()
+        }
+    };
+
+    let input = match QueryModuleFragmentDeriveInput::from_derive_input(&derive_input) {
+        Ok(input) => input,
+        Err(e) => return e.write_errors(),
+    };
+
+    match fragment_derive_impl(
+        input.to_fragment_derive_input(&args.schema_path, &args.query_module),
+    ) {
+        Ok(res) => res,
+        Err(e) => e.to_compile_error(),
+    }
+}

--- a/cynic-codegen/src/query_module/utils.rs
+++ b/cynic-codegen/src/query_module/utils.rs
@@ -60,7 +60,7 @@ pub fn strip_cynic_attrs(item: syn::Item) -> syn::Item {
                 field.attrs = field
                     .attrs
                     .iter()
-                    .filter(|attr| !attr.path.is_ident("cynic_arguments"))
+                    .filter(|attr| !is_cynic_attr(&attr.path))
                     .cloned()
                     .collect();
             }
@@ -76,6 +76,10 @@ pub fn strip_cynic_attrs(item: syn::Item) -> syn::Item {
         }
         other => other,
     }
+}
+
+fn is_cynic_attr(path: &syn::Path) -> bool {
+    path.is_ident("cynic_arguments") || path.is_ident("cynic")
 }
 
 fn filter_cynic_attrs(attrs: Vec<Attribute>) -> Vec<Attribute> {

--- a/cynic-codegen/src/query_module/utils.rs
+++ b/cynic-codegen/src/query_module/utils.rs
@@ -1,0 +1,158 @@
+use syn::{Item, Meta, MetaList, NestedMeta};
+
+#[derive(Debug, PartialEq)]
+pub enum Derive {
+    QueryFragment,
+}
+
+pub fn find_derives(item: &Item) -> Vec<Derive> {
+    if let Item::Struct(s) = item {
+        let attr = s.attrs.iter().find(|attr| attr.path.is_ident("derive"));
+
+        if let None = attr {
+            return vec![];
+        }
+        let attr = attr.unwrap();
+
+        let meta_list = match attr.parse_meta() {
+            Ok(Meta::List(list)) => list,
+            _ => {
+                return vec![];
+            }
+        };
+
+        return meta_list
+            .nested
+            .iter()
+            .map(derive_for_nested_meta)
+            .flatten()
+            .collect();
+    }
+
+    return vec![];
+}
+
+fn derive_for_nested_meta(nested: &NestedMeta) -> Option<Derive> {
+    if let NestedMeta::Meta(Meta::Path(path)) = nested {
+        if let Some(last) = path.segments.last() {
+            match last.ident.to_string().as_ref() {
+                "QueryFragment" => return Some(Derive::QueryFragment),
+                _ => (),
+            }
+        }
+    }
+    return None;
+}
+
+pub fn strip_cynic_attrs(item: syn::Item) -> syn::Item {
+    let mut item = item;
+    match item {
+        Item::Struct(mut s) => {
+            s.attrs = s
+                .attrs
+                .into_iter()
+                .filter(|attr| !attr.path.is_ident("cynic"))
+                .map(|attr| {
+                    if attr.path.is_ident("derive") {
+                        let mut meta_list = match attr.parse_meta() {
+                            Ok(Meta::List(list)) => list,
+                            _ => return attr,
+                        };
+                        meta_list.nested = meta_list
+                            .nested
+                            .into_iter()
+                            .filter(|nested| derive_for_nested_meta(nested).is_none())
+                            .collect();
+
+                        // TODO: test this fucker
+
+                        syn::parse_quote! {
+                            #[#meta_list]
+                        }
+                    } else {
+                        attr
+                    }
+                })
+                .collect();
+
+            for field in &mut s.fields {
+                field.attrs = field
+                    .attrs
+                    .iter()
+                    .filter(|attr| !attr.path.is_ident("cynic_arguments"))
+                    .cloned()
+                    .collect();
+            }
+
+            Item::Struct(s)
+
+            // TODO: Do a filter on field attributes as well.
+        }
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+
+    #[test]
+    fn test_find_derives_with_fragment() {
+        let item: syn::Item = syn::parse2(quote! {
+            #[derive(Debug, cynic::QueryFragment)]
+            struct Something {}
+        })
+        .unwrap();
+
+        assert_eq!(find_derives(&item), vec![Derive::QueryFragment]);
+    }
+
+    #[test]
+    fn test_find_derives_when_no_cynic_derive() {
+        let item: syn::Item = syn::parse2(quote! {
+            #[derive(Debug)]
+            struct Something {}
+        })
+        .unwrap();
+
+        assert_eq!(find_derives(&item), vec![]);
+    }
+
+    #[test]
+    fn test_find_derives_when_no_derive() {
+        let item: syn::Item = syn::parse2(quote! {
+            struct Something {}
+        })
+        .unwrap();
+
+        assert_eq!(find_derives(&item), vec![]);
+    }
+
+    #[test]
+    fn test_strip_cynic_attrs() {
+        let input: syn::Item = syn::parse2(quote! {
+            #[derive(Debug, cynic::QueryFragment, serde::Serialize)]
+            #[cynic(query_path = "something")]
+            #[serde(something)]
+            struct Something {
+                #[cynic_arguments(x = "1")]
+                field: i32,
+                other_field: f32
+            }
+        })
+        .unwrap();
+
+        let expected: syn::Item = syn::parse2(quote! {
+            #[derive(Debug, serde::Serialize)]
+            #[serde(something)]
+            struct Something {
+                field: i32,
+                other_field: f32
+            }
+        })
+        .unwrap();
+
+        assert_eq!(strip_cynic_attrs(input), expected)
+    }
+}

--- a/cynic-codegen/src/query_module/utils.rs
+++ b/cynic-codegen/src/query_module/utils.rs
@@ -98,8 +98,6 @@ fn filter_cynic_attrs(attrs: Vec<Attribute>) -> Vec<Attribute> {
                     .filter(|nested| derive_for_nested_meta(nested).is_none())
                     .collect();
 
-                // TODO: test this fucker
-
                 syn::parse_quote! {
                     #[#meta_list]
                 }

--- a/cynic-proc-macros/src/lib.rs
+++ b/cynic-proc-macros/src/lib.rs
@@ -3,7 +3,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 
 use cynic_codegen::{
-    fragment_arguments_derive, fragment_derive, inline_fragments_derive, query_dsl,
+    fragment_arguments_derive, fragment_derive, inline_fragments_derive, query_dsl, query_module,
     scalars_as_strings,
 };
 
@@ -67,6 +67,21 @@ pub fn inline_fragments_derive(input: TokenStream) -> TokenStream {
     };
 
     //eprintln!("{}", rv);
+
+    rv
+}
+
+#[proc_macro_attribute]
+pub fn query_module(attrs: TokenStream, input: TokenStream) -> TokenStream {
+    let module = syn::parse_macro_input!(input as syn::ItemMod);
+    let attrs = syn::parse_macro_input!(attrs as syn::AttributeArgs);
+
+    let rv: TokenStream = match query_module::transform_query_module(attrs, module) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_error().into(),
+    };
+
+    // eprintln!("{}", rv);
 
     rv
 }

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -75,7 +75,11 @@ pub fn document_to_fragment_structs(
                     field_path.push(field.name);
                     let field_ty = type_index.type_for_path(&field_path)?;
 
-                    lines.push(format!("        pub {}: {},", field.name, field_ty.type_spec()))
+                    lines.push(format!(
+                        "        pub {}: {},",
+                        field.name,
+                        field_ty.type_spec()
+                    ))
                 }
                 lines.push(format!("    }}\n"));
             }

--- a/cynic/examples/simple_v2.rs
+++ b/cynic/examples/simple_v2.rs
@@ -1,0 +1,127 @@
+fn main() {
+    use queries::{TestArgs, TestStruct};
+
+    //println!("{}", cynic::Query::new<TestStruct>(TestArgs {}));
+}
+
+mod query_dsl {
+    type Json = serde_json::Value;
+
+    cynic::query_dsl!("cynic/examples/simple.graphql");
+}
+
+use cynic::selection_set;
+
+#[cynic::query_module(
+    schema_path = "cynic/examples/simple.graphql",
+    query_module = "query_dsl"
+)]
+mod queries {
+    use super::query_dsl;
+
+    #[derive(Clone, cynic::FragmentArguments)]
+    pub struct TestArgs {}
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "TestStruct", argument_struct = "TestArgs")]
+    pub struct TestStruct {
+        #[cynic_arguments(x = Some(1), y = Some("1".to_string()))]
+        field_one: String,
+        nested: Nested,
+        opt_nested: Option<Nested>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "Nested")]
+    pub struct Nested {
+        a_string: String,
+        opt_string: Option<String>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "TestStruct")]
+    pub struct Test {
+        #[cynic_arguments(x = Some(1), y = Some("1".to_string()))]
+        field_one: String,
+    }
+
+    impl Test {
+        fn new(field_one: String) -> Self {
+            Test { field_one }
+        }
+    }
+
+    #[derive(cynic::InlineFragments)]
+    #[cynic(
+        schema_path = "cynic/examples/simple.graphql",
+        query_module = "query_dsl",
+        graphql_type = "MyUnionType"
+    )]
+    pub enum MyUnionType {
+        Test(Test),
+        Nested(Nested),
+    }
+}
+
+/*
+fn query() {
+    let query = query_dsl::Query::test_struct(selection_set::map2(
+        TestStruct::new,
+        query_dsl::TestStruct::field_one(),
+        query_dsl::TestStruct::nested(selection_set::map(
+            Nested::new,
+            query_dsl::Nested::a_string(),
+        )),
+    ));
+}*/
+
+impl cynic::QueryRoot for query_dsl::TestStruct {}
+
+// TODO: Some sort of ToQuery trait
+// That's only implemented when QueryFragment::SelectionSet::TypeLock == RootQuery
+// TODO: I should figure out how arguments could work?
+
+/*
+
+impl cynic::QueryFragment<'static> for TestStruct {
+    type SelectionSet = selection_set::SelectionSet<'static, Self, query_dsl::TestStruct>;
+    type Arguments = ArgStruct;
+
+    fn query() -> Self::SelectionSet {
+        // TODO: Got to say I'm not that enamoured with this syntax.
+        // Is there a better way to write this?
+        selection_set::map2(
+            TestStruct::new,
+            query_dsl::TestStruct::field_one(),
+            query_dsl::TestStruct::nested(Nested::selection_set()),
+        )
+    }
+}
+
+impl cynic::QueryFragment<'static> for Nested {
+    type SelectionSet = selection_set::SelectionSet<'static, Self, query_dsl::Nested>;
+
+    fn query() -> Self::SelectionSet {
+        selection_set::map(Nested::new, query_dsl::Nested::a_string())
+    }
+}
+*/
+
+mod test {
+
+    type JSON = serde_json::Value;
+
+    // A custom scalars.
+    pub struct DateTime {}
+
+    impl cynic::Scalar for DateTime {
+        fn decode(_: &serde_json::Value) -> Result<Self, json_decode::DecodeError> {
+            Ok(DateTime {})
+        }
+    }
+
+    // Another custom scalar
+    struct Upload;
+
+    //cynic::query_dsl!("cms-schema.gql");
+}

--- a/cynic/examples/simple_v2.rs
+++ b/cynic/examples/simple_v2.rs
@@ -52,11 +52,7 @@ mod queries {
     }
 
     #[derive(cynic::InlineFragments)]
-    #[cynic(
-        schema_path = "cynic/examples/simple.graphql",
-        query_module = "query_dsl",
-        graphql_type = "MyUnionType"
-    )]
+    #[cynic(graphql_type = "MyUnionType")]
     pub enum MyUnionType {
         Test(Test),
         Nested(Nested),

--- a/cynic/examples/simple_v2.rs
+++ b/cynic/examples/simple_v2.rs
@@ -59,49 +59,7 @@ mod queries {
     }
 }
 
-/*
-fn query() {
-    let query = query_dsl::Query::test_struct(selection_set::map2(
-        TestStruct::new,
-        query_dsl::TestStruct::field_one(),
-        query_dsl::TestStruct::nested(selection_set::map(
-            Nested::new,
-            query_dsl::Nested::a_string(),
-        )),
-    ));
-}*/
-
 impl cynic::QueryRoot for query_dsl::TestStruct {}
-
-// TODO: Some sort of ToQuery trait
-// That's only implemented when QueryFragment::SelectionSet::TypeLock == RootQuery
-// TODO: I should figure out how arguments could work?
-
-/*
-
-impl cynic::QueryFragment<'static> for TestStruct {
-    type SelectionSet = selection_set::SelectionSet<'static, Self, query_dsl::TestStruct>;
-    type Arguments = ArgStruct;
-
-    fn query() -> Self::SelectionSet {
-        // TODO: Got to say I'm not that enamoured with this syntax.
-        // Is there a better way to write this?
-        selection_set::map2(
-            TestStruct::new,
-            query_dsl::TestStruct::field_one(),
-            query_dsl::TestStruct::nested(Nested::selection_set()),
-        )
-    }
-}
-
-impl cynic::QueryFragment<'static> for Nested {
-    type SelectionSet = selection_set::SelectionSet<'static, Self, query_dsl::Nested>;
-
-    fn query() -> Self::SelectionSet {
-        selection_set::map(Nested::new, query_dsl::Nested::a_string())
-    }
-}
-*/
 
 mod test {
 

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -245,5 +245,5 @@ pub struct QueryBody<'a> {
 }
 
 pub use cynic_proc_macros::{
-    query_dsl, scalars_as_strings, FragmentArguments, InlineFragments, QueryFragment,
+    query_dsl, query_module, scalars_as_strings, FragmentArguments, InlineFragments, QueryFragment,
 };


### PR DESCRIPTION
This adds a query_module attribute macro that can be applied to a module containing QueryFragments & InlineFragments.  This was intended as an optimisation so that each individual derive macro invocation didn't have to load the graphql schema for itself.  Turns out this was not really a bottleneck - with the github GQL test app I'm using the builds still take about 20 seconds.  Seems like the slow bit is rust parsing the query_dsl.

Despite this, query_modules do offer some advantages:

1. They allow us to consolidate some of the parameters that each of our derive macros take - instead of providing the query_dsl & schema_path on each struct you can do it once on the query_module macro.
2. They open up the possibility of dropping the `graphql_type` annotation as well - if we can figure out the types by walking the query struct tree then we could potentially figure this out for ourselves.  Haven't implemented this yet, but it seems like it might be a nice addition...