### PR TITLE
Drop Serialize requirement for enums & input types.

### DIFF
--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -91,6 +91,16 @@ pub fn enum_derive_impl(
                     })
                 }
             }
+
+            impl ::cynic::SerializableArgument for #ident {
+                fn serialize(&self) -> Result<serde_json::Value, ()> {
+                    ::serde_json::to_value(match self {
+                        #(
+                            #ident::#variants => #string_literals.to_string(),
+                        )*
+                    }).map_err(|_| ())
+                }
+            }
         })
     } else {
         Err(syn::Error::new(

--- a/cynic-codegen/src/query_dsl/argument_struct.rs
+++ b/cynic-codegen/src/query_dsl/argument_struct.rs
@@ -89,7 +89,7 @@ impl quote::ToTokens for ArgumentStruct {
             quote! {
                 vec![
                     #(
-                        ::cynic::Argument::new_serialize(
+                        ::cynic::Argument::from_serializable(
                             #argument_strings,
                             #argument_gql_types,
                             self.#argument_names
@@ -103,7 +103,7 @@ impl quote::ToTokens for ArgumentStruct {
 
                 #(
                     if self.#argument_names.is_some() {
-                        args.push(::cynic::Argument::new_serialize(
+                        args.push(::cynic::Argument::from_serializable(
                             #argument_strings,
                             #argument_gql_types,
                             self.#argument_names

--- a/cynic-codegen/src/scalar_derive/mod.rs
+++ b/cynic-codegen/src/scalar_derive/mod.rs
@@ -43,6 +43,9 @@ pub fn scalar_derive_impl(input: ScalarDeriveInput) -> Result<TokenStream, syn::
             fn decode(value: &serde_json::Value) -> Result<Self, ::cynic::DecodeError> {
                 Ok(#ident(<#inner_type as ::cynic::Scalar>::decode(value)?))
             }
+            fn encode(&self) -> Result<serde_json::Value, ()> {
+                Ok(self.0.encode()?)
+            }
         }
     })
 }

--- a/cynic-codegen/src/struct_field.rs
+++ b/cynic-codegen/src/struct_field.rs
@@ -91,16 +91,12 @@ impl GenericConstraint {
             GenericConstraint::Enum(ident) => {
                 let type_path = TypePath::concat(&[path_to_markers, ident.clone().into()]);
 
-                // TODO: For now putting a serialize requirement here.
-                // Kinda want to get away from needing that, but for now it's needed.
-                quote! { ::cynic::Enum<#type_path> + ::serde::Serialize }
+                quote! { ::cynic::Enum<#type_path> + ::cynic::SerializableArgument }
             }
             GenericConstraint::InputObject(ident) => {
                 let type_path = TypePath::concat(&[path_to_markers, ident.clone().into()]);
 
-                // TODO: For now putting a serialize requirement here.
-                // Kinda want to get away from needing that, but for now it's needed.
-                quote! { ::cynic::InputObject<#type_path> + ::serde::Serialize }
+                quote! { ::cynic::InputObject<#type_path> + ::cynic::SerializableArgument }
             }
         }
     }

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -93,9 +93,7 @@ pub fn document_to_fragment_structs(
             }
             PotentialStruct::Enum(en) => {
                 let type_name = en.def.name;
-                lines.push(
-                    "    #[derive(cynic::Enum, Clone, Copy, serde::Serialize, Debug)]".into(),
-                );
+                lines.push("    #[derive(cynic::Enum, Clone, Copy, Debug)]".into());
                 lines.push(format!("    #[cynic(graphql_type = \"{}\")]", type_name));
                 lines.push(format!("    pub enum {} {{", type_name.to_pascal_case()));
 
@@ -118,7 +116,7 @@ pub fn document_to_fragment_structs(
     for def in &schema.definitions {
         match def {
             schema::Definition::TypeDefinition(schema::TypeDefinition::Scalar(scalar)) => {
-                lines.push("    #[derive(cynic::Scalar, Debug, serde::Serialize)]".into());
+                lines.push("    #[derive(cynic::Scalar, Debug)]".into());
                 lines.push(format!(
                     "    pub struct {}(String);\n",
                     scalar.name.to_pascal_case()

--- a/cynic/examples/simple.rs
+++ b/cynic/examples/simple.rs
@@ -121,6 +121,9 @@ mod test {
         fn decode(_: &serde_json::Value) -> Result<Self, json_decode::DecodeError> {
             Ok(DateTime {})
         }
+        fn encode(&self) -> Result<serde_json::Value, ()> {
+            todo!()
+        }
     }
 
     // Another custom scalar

--- a/cynic/examples/simple_v2.rs
+++ b/cynic/examples/simple_v2.rs
@@ -83,6 +83,9 @@ mod test {
         fn decode(_: &serde_json::Value) -> Result<Self, json_decode::DecodeError> {
             Ok(DateTime {})
         }
+        fn encode(&self) -> Result<serde_json::Value, ()> {
+            todo!()
+        }
     }
 
     // Another custom scalar

--- a/cynic/src/argument.rs
+++ b/cynic/src/argument.rs
@@ -1,3 +1,5 @@
+use crate::{Enum, InputObject, Scalar};
+
 pub struct Argument {
     pub(crate) name: String,
     pub(crate) value: Result<serde_json::Value, ()>,
@@ -13,12 +15,50 @@ impl Argument {
         }
     }
 
-    pub fn new_serialize<V: serde::Serialize>(name: &str, gql_type: &str, value: V) -> Self {
+    pub fn from_serializable(
+        name: &str,
+        gql_type: &str,
+        value: impl SerializableArgument,
+    ) -> Argument {
         Argument {
             name: name.to_string(),
-            // TODO: should actually pass up the Err here...
-            value: serde_json::to_value(value).map_err(|_| ()),
+            value: value.serialize(),
             type_: gql_type.to_string(),
         }
+    }
+}
+
+pub trait SerializableArgument {
+    fn serialize(&self) -> Result<serde_json::Value, ()>;
+}
+
+// All Input objects are serializable.
+impl<TypeLock> SerializableArgument for dyn crate::InputObject<TypeLock> {
+    fn serialize(&self) -> Result<serde_json::Value, ()> {
+        self.serialize()
+    }
+}
+
+impl<T: SerializableArgument> SerializableArgument for Vec<T> {
+    fn serialize(&self) -> Result<serde_json::Value, ()> {
+        self.iter()
+            .map(|s| s.serialize())
+            .collect::<Result<Vec<_>, _>>()
+            .map(serde_json::Value::Array)
+    }
+}
+
+impl<T: SerializableArgument> SerializableArgument for Option<T> {
+    fn serialize(&self) -> Result<serde_json::Value, ()> {
+        match self {
+            Some(inner) => Ok(inner.serialize()?),
+            None => Ok(serde_json::Value::Null),
+        }
+    }
+}
+
+impl<T: Scalar> SerializableArgument for T {
+    fn serialize(&self) -> Result<serde_json::Value, ()> {
+        self.encode()
     }
 }

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -226,7 +226,6 @@ pub trait InputObject<TypeLock> {
     fn serialize(&self) -> Result<serde_json::Value, ()>;
 }
 
-
 /// A marker trait for the arguments types on QueryFragments.
 ///
 /// We use this in combination with the IntoArguments trait below

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -167,7 +167,7 @@ pub mod utils;
 
 pub use json_decode::DecodeError;
 
-pub use argument::Argument;
+pub use argument::{Argument, SerializableArgument};
 pub use id::Id;
 pub use query::Query;
 pub use result::{GraphQLError, GraphQLResponse, GraphQLResult, PossiblyParsedData};
@@ -222,7 +222,10 @@ pub trait Enum<TypeLock>: Sized {
 /// This trait is generic over some TypeLock which is used to tie an InputType
 /// back into it's GraphQL input object.  Generally this will be some type
 /// generated in the GQL code.
-pub trait InputObject<TypeLock> {}
+pub trait InputObject<TypeLock> {
+    fn serialize(&self) -> Result<serde_json::Value, ()>;
+}
+
 
 /// A marker trait for the arguments types on QueryFragments.
 ///

--- a/cynic/src/scalar.rs
+++ b/cynic/src/scalar.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 
 pub trait Scalar: Sized {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError>;
+    fn encode(&self) -> Result<serde_json::Value, ()>;
 }
 
 pub fn decoder<'a, S>() -> BoxDecoder<'a, S>
@@ -18,11 +19,19 @@ impl Scalar for i64 {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
         json_decode::integer().decode(value)
     }
+
+    fn encode(&self) -> Result<serde_json::Value, ()> {
+        Ok((*self).into())
+    }
 }
 
 impl Scalar for f64 {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
         json_decode::float().decode(value)
+    }
+
+    fn encode(&self) -> Result<serde_json::Value, ()> {
+        Ok((*self).into())
     }
 }
 
@@ -30,17 +39,29 @@ impl Scalar for bool {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
         json_decode::boolean().decode(value)
     }
+
+    fn encode(&self) -> Result<serde_json::Value, ()> {
+        Ok((*self).into())
+    }
 }
 
 impl Scalar for String {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
         json_decode::string().decode(value)
     }
+
+    fn encode(&self) -> Result<serde_json::Value, ()> {
+        Ok(self.clone().into())
+    }
 }
 
 impl Scalar for serde_json::Value {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
         json_decode::json().decode(value)
+    }
+
+    fn encode(&self) -> Result<serde_json::Value, ()> {
+        Ok(self.clone())
     }
 }
 


### PR DESCRIPTION
Prior to this change, enums & input types needed to implement serde::Serialize, as it was
used by the Arguments struct to serialize things to JSON for sending to servers.

This didn't actually work without a lot of work though, as Serialize is not aware of the
transformations that cynic::Enum applies to enums, or any renames that an eventual
derive for cynic::InputType will apply, so you'd need to manually tell serde about all
these things.

This fixes that by adding a new cynic::SerializableArgument trait.  This is automatically
implemented for InputTypes using a blanket impl, and is derived for enums when deriving
cynic::Enum.  Wanted to do a blanket derive on cynic::Enum but couldn't for rust reasons.

Fixes #25 